### PR TITLE
added new module

### DIFF
--- a/phases/mahalanobis.py
+++ b/phases/mahalanobis.py
@@ -1,0 +1,19 @@
+# phases/mahalanobis.py
+
+import numpy as np
+from sklearn.covariance import EmpiricalCovariance
+
+def train_mahalanobis_model(embeddings: list[np.ndarray]) -> EmpiricalCovariance:
+    """
+    Fit a Mahalanobis model using the provided embedding vectors.
+    """
+    matrix = np.stack(embeddings)
+    model = EmpiricalCovariance()
+    model.fit(matrix)
+    return model
+
+def compute_mahalanobis_distance(model: EmpiricalCovariance, vector: np.ndarray) -> float:
+    """
+    Compute Mahalanobis distance from the given vector to the trained model distribution.
+    """
+    return model.mahalanobis([vector])[0]

--- a/phases/stability.py
+++ b/phases/stability.py
@@ -1,10 +1,11 @@
-# phases\stability.py
+# phases/stability.py
 
 import networkx as nx
 import numpy as np
 import spacy
 from transformers import AutoTokenizer, AutoModel
 import torch
+from phases.mahalanobis import train_mahalanobis_model, compute_mahalanobis_distance
 
 # Load spaCy for parsing
 nlp = spacy.load("en_core_web_sm")
@@ -102,11 +103,17 @@ def analyze_stability(proposition: str) -> str:
     ]
     avg_similarity = float(np.mean(similarities))
 
+    # Compute Mahalanobis dispersion
+    concept_vecs = list(vectors.values())
+    mahal_model = train_mahalanobis_model(concept_vecs)
+    mahal_distances = [compute_mahalanobis_distance(mahal_model, vec) for vec in concept_vecs]
+    avg_mahalanobis = float(np.mean(mahal_distances))
+
     # Format the result
     return (
         f"Graph nodes: {G.number_of_nodes()}\n"
         f"Graph edges: {G.number_of_edges()}\n"
         f"Average semantic coherence (cosine): {avg_similarity:.3f}\n"
+        f"Average semantic dispersion (Mahalanobis): {avg_mahalanobis:.3f}\n"
         f"Concepts: {concepts}\n"
     )
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ networkx
 spacy
 transformers
 torch
+scikit-learn


### PR DESCRIPTION
## Title: Add Mahalanobis Measurement

### Summary
This pull request introduces Mahalanobis distance analysis to the epistemic stability phase. The goal is to measure semantic dispersion across concept embeddings, providing a secondary metric alongside average cosine similarity. This enhances the stability analysis by capturing latent outliers and structural variance in conceptual space.

### Related Issues
_No related issues._

### Changes Made
- Created new module `phases/mahalanobis.py` to encapsulate Mahalanobis model training and scoring
- Modified `phases/stability.py` to:
  - Import Mahalanobis functions
  - Compute average Mahalanobis distance across concept vectors
  - Include dispersion results in the final stability output
- Updated `requirements.txt` to include `scikit-learn` as a dependency

### Checklist
- [x] Code compiles and passes linting
- [ ] Added or updated relevant tests
- [ ] Updated documentation if necessary
- [x] Manually tested major features

### Implementation Notes
- Uses `EmpiricalCovariance` from `scikit-learn` to fit a distribution over concept vectors extracted from BERT.
- Measures each concept's Mahalanobis distance from the cluster center to quantify epistemic anomaly or dispersion.
- The Mahalanobis logic is modularized for future reuse across other analysis phases.


### Next Steps (optional)
- Visualize Mahalanobis dispersion across propositions or clusters
- Introduce philosophical lens-specific Mahalanobis baselines for drift detection
- Add CLI flag to export raw distances for further statistical processing

---

